### PR TITLE
Applied corrections from Joonwoong

### DIFF
--- a/draft-sharabayko-mops-srt.md
+++ b/draft-sharabayko-mops-srt.md
@@ -47,6 +47,8 @@ informative:
   RFC8174:
   RFC8216:
   RFC3031:
+  RFC8312:
+  RFC4987:
   GHG04b:
     title: Experiences in Design and Implementation of a High Performance Transport Protocol
     author:
@@ -1831,7 +1833,7 @@ It also determines the interval of periodic NAK packets to be reported to the se
 
 ### File Transfer Congestion Control (FileCC)
 
-For file transfer, any known File Congestion Control algorithms, like CUBIC {{rfc8312}}, can apply,
+For file transfer, any known File Congestion Control algorithms, like CUBIC {{RFC8312}}, can apply,
 including the congestion control mechanism proposed in UDT {{GHG04b}}.
 The UDT congestion control relies on the available link capacity, packet loss reports (NAK)
 and packet acknowledgements (ACKs).

--- a/draft-sharabayko-mops-srt.md
+++ b/draft-sharabayko-mops-srt.md
@@ -172,8 +172,9 @@ Since RTMP, HLS and DASH rely on TCP, these protocols can only guarantee accepta
 reliability over connections with low RTTs, and can not use the bandwidth of network 
 connections to their full extent due to limitations imposed by congestion control. 
 Notably, QUIC{{I-D.ietf-quic-transport}} has been designed to address these problems with HTTP-based delivery 
-protocols in HTTP/3{{I-D.ietf-quic-http}}. Like QUIC, SRT{{SRTSRC}} uses UDP instead of the TCP transport protocol, 
-but includes features which assure more reliable delivery. 
+protocols in HTTP/3{{I-D.ietf-quic-http}}. Like QUIC, SRT{{SRTSRC}} uses UDP instead of the TCP transport protocol,
+but assures more reliable delivery using Automatic Repeat Request (ARQ), packet acknowledgements,
+end-to-end latency management, etc.
 
 ## Secure Reliable Transport Protocol 
 
@@ -187,7 +188,7 @@ connectivity, while less expensive, imposes significant bandwidth overhead to ac
 the necessary level of packet loss recovery. Introducing selective packet retransmission 
 (reliable UDP) to recover from packet loss removes those limitations.  
 
-Derived from the UDP-based Data Transfer protocol (UDT), SRT is a user-level protocol 
+Derived from the UDP-based Data Transfer protocol{{GHG04b}} (UDT), SRT is a user-level protocol 
 that retains most of the core concepts and mechanisms while introducing several 
 refinements and enhancements, including control packet modifications, improved flow 
 control for handling live streaming, enhanced congestion control, and a mechanism for 
@@ -209,9 +210,8 @@ of a stream from a source network are completely changed by transmission over th
 internet, which introduces delays, jitter, and packet loss. This, in turn, leads to 
 problems with decoding, as the audio and video decoders do not receive packets at the 
 expected times. The use of large buffers helps, but latency is increased. 
-
-SRT includes a mechanism that recreates the signal characteristics on the receiver side, 
-reducing the need for buffering.
+SRT includes a mechanism to keep a constant end-to-end latency, thus recreating
+the signal characteristics on the receiver side, and reducing the need for buffering.
 
 Like TCP, SRT employs a listener/caller model. The data flow is bi-directional and 
 independent of the connection initiation - either the sender or receiver can operate 
@@ -385,7 +385,7 @@ Control Information Field (variable length):
 : The use of this field is defined by the Control Type field of the control packet.
 
 The types of SRT control packets are shown in {{srt-ctrl-pkt-type-table}}.
-The value "0x7ffff" is reserved for a user-defined type.
+The value "0x7FFF" is reserved for a user-defined type.
 
 | ----------------- | ------------ | ------- | -------------------------- |
 | Packet Type       | Control Type | Subtype | Section                    |
@@ -617,10 +617,11 @@ Version (V): 3 bits. Value: {1}
 
 Packet Type (PT): 4 bits. Value: {2}  
 : This is a fixed-width field that indicates the Packet Type:
+
   - 0: Reserved
-  - 1: MSmsg
-  - 2: KMmsg 
-  - 7: Reserved to discriminate MPEG-TS packet (0x47=sync byte)   
+  - 1: Media Stream Message (MSmsg)
+  - 2: Keying Material Message (KMmsg)
+  - 7: Reserved to discriminate MPEG-TS packet (0x47=sync byte)
 
 Signature (Sign): 16 bits. Value: {0x2029}  
 : This is a fixed-width field that contains the signature ‘HAI‘ encoded as a 
@@ -631,28 +632,33 @@ Reserved (Resv): 6 bits. Value: {0}
 
 Key-based Data Encryption (KK): 2 bits.
 : This is a fixed-width field that indicates whether or not data is encrypted:
+
   - 00b: not encrypted (data packets only)
   - 01b: even key
-  - 10b: odd key   
-  - 11b: even and odd keys   
+  - 10b: odd key
+  - 11b: even and odd keys
 
-Key Encryption Key Index (KEKI): 32 bits. Value: {0}  
+Key Encryption Key Index (KEKI): 32 bits. Value: {0}
 : This is a fixed-width field for specifying the KEK index (big endian order)
+
   - 0: Default stream associated key (stream/system default)
   - 1..255: Reserved for manually indexed keys
 
 Cipher ( ): 8 bits. Value: {0..2}
 : This is a fixed-width field for specifying encryption cipher and mode:
+
   - 0: None or KEKI indexed crypto context
   - 1: AES-ECB (not supported in SRT)
   - 2: AES-CTR {{SP800-38A}}
 
 Authentication (Auth): 8 bits. Value: {0}  
 : This is a fixed-width field for specifying a message authentication code algorithm:
+
   - 0: None or KEKI indexed crypto context
 
 Stream Encapsulation (SE): 8 bits. Value: {2}  
 : This is a fixed-width field for describing the stream encapsulation:
+
   - 0: Unspecified or KEKI indexed crypto context
   - 1: MPEG-TS/UDP
   - 2: MPEG-TS/SRT
@@ -664,20 +670,21 @@ Reserved (Resv2): 16 bits. Value: {0}
 : This is a fixed-width field reserved for future use.
 
 Slen/4 ( ): 4 bits. Value: {0..255}  
-: This is a fixed-width field for specifying salt length in bytes divided by 4. 
+: This is a fixed-width field for specifying salt length in bytes divided by 4.
   Can be zero if no salt/IV present
 
 Klen/4 ( ): 8 bits. Value: {4,6,8}  
-: This is a fixed-width field for specifying SEK length in bytes divided by 4. 
+: This is a fixed-width field for specifying SEK length in bytes divided by 4.
   Size of one key even if two keys present.
 
 Salt (Slen): Slen*8 bits. Value: { }  
 : This is a variable-width field for specifying a salt key 
 
-Wrap ( ): (64+n * Klen * 8) bits. Value: { }  
+Wrap ( ): (64+n * Klen * 8) bits. Value: { }
 : This is a variable-width field for specifying Wrapped key(s), where n = 1 or 2
+
   NOTE 1: n = (KK + 1)/2
-  NOTE 2: size in bytes = (((KK+1/2) * Klen) + 8)   
+  NOTE 2: size in bytes = (((KK+1/2) * Klen) + 8)
 
 ~~~
  0                   1                   2                   3
@@ -827,7 +834,7 @@ There are several types of ACK packets:
 - A Small ACK includes the fields up to and including the Available Buffer Size field. 
   The Type-specific Information field should be set to 0.
 
-The sender only acknowledges the receipt of Full ACK packets (see ACKACK).
+The sender only acknowledges the receipt of Full ACK packets (see ACKACK Section {{ctrl-pkt-ackack}}).
 
 The Lite ACK and Small ACK packets are used in cases when the receiver should acknowledge
 received data packets more often than every 10 ms. This is usually needed at high data rates.
@@ -955,8 +962,8 @@ as specified in this section.
 ## Stream Multiplexing
 
 Multiple SRT sockets may share the same UDP socket so that the packets
-received to this UDP socket will be correctly dispatched to the
-SRT socket they are currently destined.
+received to this UDP socket will be correctly dispatched to those
+SRT sockets they are currently destined.
 
 During the handshake, the parties exchange their SRT Socket IDs.
 These IDs are then used in the Destination Socket ID field of
@@ -1014,7 +1021,7 @@ portions of any size.
 
 ## Handshake Messages {#handshake-messages}
 
-SRT is a connection protocol. It embraces the concepts of "connection"
+SRT is a connection-oriented protocol. It embraces the concepts of "connection"
 and "session". The UDP system protocol is used by SRT for sending data
 and control packets.
 
@@ -1097,11 +1104,11 @@ connection. See the list of error codes in {{hs-rej-reason}}.
  | 1015 | REJ_GROUP        | incompatible group                      |
 {: #hs-rej-reason title="Handshake Rejection Reason Codes"}
 
-The specification of the cipher family and block size is decided by the Sender. When the transmission 
-is bidirectional, this value must be agreed upon at the outset because when both 
-are set the Responder wins. For Caller-Listener connections it is reasonable to 
-set this value on the Listener only. In the case of Rendezvous the only reasonable 
-approach is to decide upon the correct value from the different sources and to 
+The specification of the cipher family and block size is decided by the data Sender.
+When the transmission is bidirectional, this value must be agreed upon at the outset
+because when both are set the Responder wins. For Caller-Listener connections it is
+reasonable to set this value on the Listener only. In the case of Rendezvous the only
+reasonable approach is to decide upon the correct value from the different sources and to 
 set it on both parties (note that **AES-128** is the default).
 
 ### Caller-Listener Handshake {#caller-listener-handshake}
@@ -1130,7 +1137,7 @@ This is due to the initial design of SRT that was to be compliant with the UDT
 protocol ({{GHG04b}}) on which it is based.
 
 This phase serves only to set a cookie on the Listener so that it
-doesn't allocate resources, thus mitigating a potential DoS attack that might be
+does not allocate resources, thus mitigating a potential DoS attack that might be
 perpetrated by flooding the Listener with handshake commands.
 
 The Listener responds with the following:
@@ -1141,9 +1148,9 @@ The Listener responds with the following:
 - Handshake Type: INDUCTION
 - SRT Socket ID: Socket ID of the Listener
 - SYN Cookie: a cookie that is crafted based on host, port and current time
-  with 1 minute accuracy
+  with 1 minute accuracy to avoid SYN flooding attack {{RFC4987}}
 
-At this point the Listener still doesn't know if the Caller is SRT or UDT,
+At this point the Listener still does not know if the Caller is SRT or UDT,
 and it responds with the same set of values regardless of whether the Caller is
 SRT or UDT.
 
@@ -1228,7 +1235,7 @@ When one party's cookie value is greater than its peer's, it wins the cookie
 contest and becomes Initiator (the other party becomes the Responder).
 
 At this point there are two possible "handshake flows":
-*serial*  and *parallel*.
+serial and parallel.
 
 #### Serial Handshake Flow
 
@@ -1243,15 +1250,15 @@ Bob has received from her.
 This process can be described easily as a series of exchanges between the first
 and following parties (Alice and Bob, respectively):
 
-1. Initially, both parties are in the *waving* state. Alice sends a handshake
+1. Initially, both parties are in the waving state. Alice sends a handshake
    message to Bob:
    - Version: 5
-   - Type: Extension field: 0, Encryption field: advertised `PBKEYLEN`.
+   - Type: Extension field: 0, Encryption field: advertised "PBKEYLEN".
    - Handshake Type: WAVEAHAND
    - SRT Socket ID: Alice's socket ID
    - SYN Cookie: Created based on host/port and current time.
 
-While Alice doesn't yet know if she is sending this message to
+While Alice does not yet know if she is sending this message to
 a Version 4 or Version 5 peer, the values from these fields would not be interpreted by
 the Version 4 peer when the Handshake Type is WAVEAHAND.
 
@@ -1291,7 +1298,7 @@ for key generation sent next in the KMREQ extension.
 4. Bob receives Alice's CONCLUSION message, and then does one of the
    following (depending on Bob's role):
    - If Bob is the Initiator (Alice's message contains HSRSP), he:
-     - switches to the "*connected" state
+     - switches to the "connected" state
      - sends Alice a message with Handshake Type AGREEMENT, but containing
        no SRT extensions (Extension Flags field should be 0)
 
@@ -1305,14 +1312,14 @@ for key generation sent next in the KMREQ extension.
 5. Alice receives the above message, enters into the "connected" state, and
    then does one of the following (depending on Alice's role):
     - If Alice is the Initiator (received CONCLUSION with HSRSP),
-      she sends Bob a message with Handshake Type = URQ_AGREEMENT.
+      she sends Bob a message with Handshake Type = AGREEMENT.
     - If Alice is the Responder, the received message has Handshake Type AGREEMENT
       and in response she does nothing.
 
 6. At this point, if Bob was Initiator, he is connected already. If he was a
    Responder, he should receive the above AGREEMENT message, after which he
    switches to the "connected" state. In the case where the UDP packet with the
-   agreement message gets lost, Bob will still enter the *connected* state once
+   agreement message gets lost, Bob will still enter the "connected" state once
    he receives anything else from Alice. If Bob is going to send, however, he
    has to continue sending the same CONCLUSION until he gets the confirmation
    from Alice.
@@ -1347,13 +1354,13 @@ Initiator:
 2. Attention
    - Receives CONCLUSION message, which:
      - contains no extensions:
-       - switches to Initiated, still sends URQ_CONCLUSION + HSREQ
+       - switches to Initiated, still sends CONCLUSION + HSREQ
      - contains `HSRSP` extension:
        - switches to Connected, sends AGREEMENT
 3. Initiated
    - Receives CONCLUSION message, which:
      - Contains no extensions:
-       - REMAINS IN THIS STATE, still sends URQ_CONCLUSION + HSREQ
+       - REMAINS IN THIS STATE, still sends CONCLUSION + HSREQ
      - contains `HSRSP` extension:
        - switches to Connected, sends AGREEMENT
 4. Connected
@@ -1367,7 +1374,7 @@ Responder:
    - Switches to Attention
    - Sends CONCLUSION message (with no extensions)
 2. Attention
-   - Receives CONCLUSION message with HSREQ
+   - Receives CONCLUSION message with HSREQ.
      This message might contain no extensions, in which case the party 
      shall simply send the empty CONCLUSION message, as before, and remain 
      in this state.
@@ -1400,7 +1407,7 @@ never become aware. The missing packet problem is resolved this way:
 3. When the Initiator switches to the Connected state it responds with a
    AGREEMENT message, which may be missed by the Responder. Nonetheless, the
    Initiator may start sending data packets because it considers itself
-   connected - it doesn't know that the Responder has not yet switched
+   connected - it does not know that the Responder has not yet switched
    to the Connected state. Therefore it is exceptionally allowed that when
    the Responder is in the Initiated state and receives a data packet
    (or any control packet that is normally sent only between connected
@@ -1410,7 +1417,7 @@ never become aware. The missing packet problem is resolved this way:
 4. If the the Initiator has already switched to the Connected state it will not
    bother the Responder with any more handshake messages. But the Responder may be
    completely unaware of that (having missed the AGREEMENT message from the
-   Initiator). Therefore it doesn't exit the connecting state, which means that it
+   Initiator). Therefore it does not exit the connecting state, which means that it
    continues sending CONCLUSION + HSRSP messages until it receives any
    packet that will make it switch to the Connected state (normally
    AGREEMENT). Only then does it exit the connecting state and the
@@ -1538,7 +1545,7 @@ extended RTT time, and the time needed to retransmit the lost packet. The value 
 is negotiated during the SRT handshake exchange and is equal to 120 milliseconds. The recommended
 value of TsbpdDelay is 3-4 times RTT.
 
-it is worth noting that TsbpdDelay limits the number of packet retransmissions to a certain extent
+It is worth noting that TsbpdDelay limits the number of packet retransmissions to a certain extent
 making impossible to retransmit packets endlessly. This is important for live data transmission.
 
 #### TSBPD Time Base Calculation {#tsbpd-time-base}
@@ -1720,14 +1727,14 @@ An ACK (from a receiver) will trigger the transmission of an ACKACK (by the send
 The time it takes for an ACK to be sent and an ACKACK to be received is the RTT.
 The ACKACK tells the receiver to stop sending the ACK position because the sender already
 knows it. Otherwise, ACKs (with outdated information) would continue to be sent regularly.
-Similarly, if the sender doesn't receive an ACK, it doesn't stop transmitting.
+Similarly, if the sender does not receive an ACK, it does not stop transmitting.
 
 There are two conditions for sending an acknowledgement. A full ACK is based on a timer of 10
 milliseconds (the ACK period). For high bit rate transmissions, a "light ACK" can be sent, which is an ACK
 for a sequence of packets. In a 10 milliseconds interval, there are often so many packets being sent and
-received that the ACK position on the sender doesn't advance quickly enough. To mitigate this,
+received that the ACK position on the sender does not advance quickly enough. To mitigate this,
 after 64 packets (even if the ACK period has not fully elapsed) the receiver sends a light ACK.
-A light ACK is a shorter ACK (header + 1 x 32-bit field). It does not trigger an ACKACK.
+A light ACK is a shorter ACK (SRT header  and one 32-bit field). It does not trigger an ACKACK.
 
 
 When a receiver encounters the situation where the next packet to be played was not
@@ -1748,13 +1755,13 @@ packets to be transmitted for the first time.
 
 The SRT sender maintains a list of lost packets (loss list) that is built from NAK reports. When
 scheduling packet transmission, it looks to see if a packet in the loss list has priority and sends it if so.
-Otherwise, it sends the next packet from the scheduled for the first transmission list.
+Otherwise, it sends the next packet scheduled for the first transmission list.
 Note that when a packet is transmitted, it stays in the buffer in case it is not received by the SRT receiver.
 
 NAK packets are processed to fill in the loss list. As the latency window advances and packets are
 dropped from the sending queue, a check is performed to see if any of the dropped or resent
 packets are in the loss list, to determine if they can be removed from there as well so that they
-are not retransmitted unnecessarily. 
+are not retransmitted unnecessarily.
 
 There is a counter for the packets that are resent. If there is no ACK
 for a packet, it will stay in the loss list and can be resent more than
@@ -1765,7 +1772,7 @@ send queue to fill. When the send queue is full, the sender will begin to drop p
 even sending them the first time. An encoder (or other application) may continue to provide
 packets, but there's no place for them, so they will end up being thrown away.
 
-This condition where packets are unsent doesn't happen often. There is a maximum number of
+This condition where packets are unsent does not happen often. There is a maximum number of
 packets held in the send buffer based on the configured latency. Older packets that have no
 chance to be retransmitted and played in time are dropped, making room for newer real-time
 packets produced by the sending application. See sections {{tsbpd}}, {{too-late-packet-drop}} for details.
@@ -1777,12 +1784,12 @@ at the time of sending the Periodic NAK report.
 An ACKACK tells the receiver to stop sending the ACK position because the sender already
 knows it. Otherwise, ACKs (with outdated information) would continue to be sent regularly.
 
-An ACK serves as a ping, with a corresponding ACKACK pong, to measure RTT. The time it 
-takes for an ACK to be sent and an ACKACK to be received is the RTT. Each ACK has a number. 
-A corresponding ACKACK has that same number. The receiver keeps a list of all ACKs in a 
-queue to match them. Unlike a full ACK, which contains the current RTT and several other 
-values in the CIF, a light ACK just contains the sequence number. All control messages 
-are sent directly and processed upon reception, but ACKACK processing time is negligible 
+An ACK serves as a ping, with a corresponding ACKACK pong, to measure RTT. The time it
+takes for an ACK to be sent and an ACKACK to be received is the RTT. Each ACK has a number.
+A corresponding ACKACK has that same number. The receiver keeps a list of all ACKs in a
+queue to match them. Unlike a full ACK, which contains the current RTT and several other
+values in the CIF, a light ACK just contains the sequence number. All control messages
+are sent directly and processed upon reception, but ACKACK processing time is negligible
 (the time this takes is included in the round-trip time).
 
 ## Bidirectional Transmission Queues
@@ -1813,17 +1820,18 @@ of congestion control algorithms.
 
 For live transmission mode ({{transmission-mode-live}}) the congestion control algorithm
 does not need to control the sending pace of the data packets, as the sending timing
-is provided by the live input. It is mainly a reactor on network events. Although certain 
+is provided by the live input source. It is mainly a reactor on network events. Certain
 limitations on the minimal inter-sending time of consecutive packets can be applied in order
-to avoid congestion during fluctuations of the source bitrate. Also, it is allowed to drop those 
-packets that can not be delivered in time.
- 
-On the receiving side, LiveCC may decide when an ACK is needed prior to ACK timeout. 
-It also determines the minimum time between consecutive packets are sent.
+to avoid congestion during fluctuations of the source bitrate.
+LiveCC determines the minimum time between consecutive packets are sent.
+Also, it is allowed to drop those packets that can not be delivered in time.
+
+On the receiving side, LiveCC may decide when an ACK is needed prior to ACK timeout.
+It also determines the interval of periodic NAK packets to be reported to the sender.
 
 ### File Transfer Congestion Control (FileCC)
 
-For file transfer, any known File Congestion Control algorithms like CUBIC and BBR can apply,
+For file transfer, any known File Congestion Control algorithms, like CUBIC {{rfc8312}}, can apply,
 including the congestion control mechanism proposed in UDT {{GHG04b}}.
 The UDT congestion control relies on the available link capacity, packet loss reports (NAK)
 and packet acknowledgements (ACKs).


### PR DESCRIPTION
#### 1. clause 1.1 and 1.2
"Like QUIC, SRT[SRTSRC] uses UDP instead
of the TCP transport protocol, but includes features which assure more reliable delivery."
-> Such as...? Reviewers may require clarification.

MAX: Fixed

"SRT includes a mechanism that recreates the signal characteristics on
the receiver side, reducing the need for buffering."
->Do we have any details for this in the draft? If not, do you think we need to add it? Otherwise we'd better to delete this sentence.

MAX: Fixed

#### 2. clause 3.2
"The types of SRT control packets are shown in Table 1. The value
"0x7ffff" is reserved for a user-defined type."
-> 0x7fff

MAX: Fixed

packet type: MSmsg?? 
-> Is it correct? HSmsg??)

MAX: MSmsg is correct, but not described in RFC. Raised issue #45.

#### 3. clause 3.2.1.2
Need to improve/correct formats. 

MAX: done.

#### 4. clause 3.2.3
Packets Receiving Rate, Receiving Rate 
-> What's difference?

MAX: Packets receiving rate is in packets/second, while the receiving rate is in bytes per second).
The calculation of both reuires a separate description though.

"see ACKACK" -> proper link to the clause is required

MAX: fixed

#### 5. clause 4
"the sender and receiver MUST handle control packets, timers,
and buffers for the connection as specified in this section."
-> Please delete MUST. I guess we can delete all the normative languages, because it is not a standard track. Not 100% certain, but..

MAX: Not sure as well. Let's keep it.

#### 6. clause 4.1
"Multiple SRT sockets may share the same UDP socket so that the
packets received to this UDP socket will be correctly dispatched to
the SRT socket they are currently destined."
-> the SRT sockets ("s" for plural)

MAX: Fixed

"These IDs are then used in the Destination Socket ID field of every
control and data packet"
->fields of control and data packets ("s" for plural)

MAX: Looks correct. The "every control and data packet" has a single form because of "every".

#### 7. clause 4.3
"SRT is a connection protocol" 
-> connection-oriented protocol?

MAX: Fixed

"The specification of the cipher family and block size is decided by
the Sender."
->Initiator/responder, caller/listener, but now sender? Needs clarification of terms, or unified/consistent uses for understanding.

MAX: The Sender encrypts the packets it sends, therefore Sender.

Cookie 
-> RFC4987 referecne may be required?

MAX: Added

#### 8. clause 4.3.2.
"_serial_" "_parallel_" -> format character? Please remove, if it's not intended.
(other clauses as well.. _waving_)

MAX: Fixed

#### 9. clause 4.3.2.1
"Encryption field: advertised "PBKEYLEN".

->Handshake type: in table 4, there is no "URQ_", but there are three instances using URQ_, such as URQ_AGREEMENT. Need clarification/corrections.

MAX: Fixed both.

#### 10. clause 4.3.2.2
Attention
"Receives CONCLUSION message with HSREQ" 
-> Full stop mark missing.

MAX: Fixed

#### 11. clause 4.5.1
"it is worth noting that TsbpdDelay..." 
-> Capitalization is needed.

MAX: Fixed

#### 12. clause 4.8.1
"A light ACK is a shorter ACK (header + 1
x 32-bit field). It does not trigger an ACKACK."
-> Is "x" means "times"? If so, which one is correct, (header + 1) x field or header + (1 x field)?

MAX: Fixed

#### 13. clause 4.8.2
"from the scheduled for
the first transmission list."
-> scheduled for the first time transmission list?

MAX: Fixed

#### 14. clause 4.11
"Although certain ..." 
-> "Certain ..."

MAX: Fixed

For live transmission mode, there is no explicit congestion control mechanism, right? Then can we claim that SRT does have "enhanced congestion control", considering the live mode is most useful/important use cases compared to other protocols? This is just a question.

MAX: "enhanced congestion control" would require additional clarifications. Let's focus on this section further on.

#### 15.
-Need references for "CUBIC" and "BBR"
-replace "doesn't" with "does not" in a few occasions.

MAX: done