### PR TITLE
ci: use local references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ script:
   - docker exec idci cp -rn /tmp/draft /home/idci
   - docker exec -w "$DRAFT_DIR" -e CI=true -e TRAVIS
       -e TRAVIS_REPO_SLUG -e TRAVIS_BRANCH -e TRAVIS_TAG -e TRAVIS_PULL_REQUEST
-      idci make CLONE_ARGS='--reference /home/idci/git-reference'
+      idci make CLONE_ARGS='--reference /home/idci/git-reference' XML2RFC_REFCACHEDIR=/home/idci/draft/references
   - docker exec idci ls -l /home/idci/draft/lib
   - if [ "${TRAVIS_TAG#draft-}" == "${TRAVIS_TAG}" ]; then
       docker exec -w "$DRAFT_DIR" -e CI=true -e GH_TOKEN -e TRAVIS
         -e TRAVIS_REPO_SLUG -e TRAVIS_BRANCH -e TRAVIS_TAG -e TRAVIS_PULL_REQUEST
-        idci make ghpages;
+        idci make XML2RFC_REFCACHEDIR=/home/idci/draft/references ghpages;
     fi
 
 deploy:
@@ -30,7 +30,7 @@ deploy:
   script:
     - docker exec -w "$DRAFT_DIR" -e CI=true -e GH_TOKEN -e TRAVIS
         -e TRAVIS_REPO_SLUG -e TRAVIS_BRANCH -e TRAVIS_TAG -e TRAVIS_PULL_REQUEST
-        idci make upload
+        idci make XML2RFC_REFCACHEDIR=/home/idci/draft/references upload
   skip_cleanup: true
   on:
     tags: true

--- a/references/reference.I-D.ietf-quic-http.xml
+++ b/references/reference.I-D.ietf-quic-http.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reference anchor="I-D.ietf-quic-http">
+   <front>
+      <title>Hypertext Transfer Protocol Version 3 (HTTP/3)</title>
+      <author fullname="Mike Bishop">
+	 <organization>Akamai</organization>
+      </author>
+      <date month="February" day="2" year="2021" />
+      <abstract>
+	 <t>   The QUIC transport protocol has several features that are desirable
+   in a transport for HTTP, such as stream multiplexing, per-stream flow
+   control, and low-latency connection establishment.  This document
+   describes a mapping of HTTP semantics over QUIC.  This document also
+   identifies HTTP/2 features that are subsumed by QUIC, and describes
+   how HTTP/2 extensions can be ported to HTTP/3.
+
+DO NOT DEPLOY THIS VERSION OF HTTP
+
+   DO NOT DEPLOY THIS VERSION OF HTTP/3 UNTIL IT IS IN AN RFC.  This
+   version is still a work in progress.  For trial deployments, please
+   use earlier versions.
+
+Note to Readers
+
+   Discussion of this draft takes place on the QUIC working group
+   mailing list (quic@ietf.org), which is archived at
+   https://mailarchive.ietf.org/arch/search/?email_list=quic.
+
+   Working Group information can be found at https://github.com/quicwg;
+   source code and issues list for this draft can be found at
+   https://github.com/quicwg/base-drafts/labels/-http.
+
+	 </t>
+      </abstract>
+   </front>
+   <seriesInfo name="Internet-Draft" value="draft-ietf-quic-http-34" />
+   <format type="TXT" target="https://www.ietf.org/internet-drafts/draft-ietf-quic-http-34.txt" />
+</reference>

--- a/references/reference.I-D.ietf-quic-transport.xml
+++ b/references/reference.I-D.ietf-quic-transport.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reference anchor="I-D.ietf-quic-transport">
+   <front>
+      <title>QUIC: A UDP-Based Multiplexed and Secure Transport</title>
+      <author fullname="Jana Iyengar">
+	 <organization>Fastly</organization>
+      </author>
+      <author fullname="Martin Thomson">
+	 <organization>Mozilla</organization>
+      </author>
+      <date month="January" day="14" year="2021" />
+      <abstract>
+	 <t>   This document defines the core of the QUIC transport protocol.  QUIC
+   provides applications with flow-controlled streams for structured
+   communication, low-latency connection establishment, and network path
+   migration.  QUIC includes security measures that ensure
+   confidentiality, integrity, and availability in a range of deployment
+   circumstances.  Accompanying documents describe the integration of
+   TLS for key negotiation, loss detection, and an exemplary congestion
+   control algorithm.
+
+DO NOT DEPLOY THIS VERSION OF QUIC
+
+   DO NOT DEPLOY THIS VERSION OF QUIC UNTIL IT IS IN AN RFC.  This
+   version is still a work in progress.  For trial deployments, please
+   use earlier versions.
+
+Note to Readers
+
+   Discussion of this draft takes place on the QUIC working group
+   mailing list (quic@ietf.org (mailto:quic@ietf.org)), which is
+   archived at https://mailarchive.ietf.org/arch/search/?email_list=quic
+
+   Working Group information can be found at https://github.com/quicwg;
+   source code and issues list for this draft can be found at
+   https://github.com/quicwg/base-drafts/labels/-transport.
+
+	 </t>
+      </abstract>
+   </front>
+   <seriesInfo name="Internet-Draft" value="draft-ietf-quic-transport-34" />
+   <format type="TXT" target="https://www.ietf.org/internet-drafts/draft-ietf-quic-transport-34.txt" />
+</reference>

--- a/references/reference.RFC.0768.xml
+++ b/references/reference.RFC.0768.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC0768' target='https://www.rfc-editor.org/info/rfc768'>
+<front>
+<title>User Datagram Protocol</title>
+<author initials='J.' surname='Postel' fullname='J. Postel'><organization /></author>
+<date year='1980' month='August' />
+</front>
+<seriesInfo name='STD' value='6'/>
+<seriesInfo name='RFC' value='768'/>
+<seriesInfo name='DOI' value='10.17487/RFC0768'/>
+</reference>

--- a/references/reference.RFC.2104.xml
+++ b/references/reference.RFC.2104.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC2104' target='https://www.rfc-editor.org/info/rfc2104'>
+<front>
+<title>HMAC: Keyed-Hashing for Message Authentication</title>
+<author initials='H.' surname='Krawczyk' fullname='H. Krawczyk'><organization /></author>
+<author initials='M.' surname='Bellare' fullname='M. Bellare'><organization /></author>
+<author initials='R.' surname='Canetti' fullname='R. Canetti'><organization /></author>
+<date year='1997' month='February' />
+<abstract><t>This document describes HMAC, a mechanism for message authentication using cryptographic hash functions. HMAC can be used with any iterative cryptographic hash function, e.g., MD5, SHA-1, in combination with a secret shared key.  The cryptographic strength of HMAC depends on the properties of the underlying hash function.  This memo provides information for the Internet community.  This memo does not specify an Internet standard of any kind</t></abstract>
+</front>
+<seriesInfo name='RFC' value='2104'/>
+<seriesInfo name='DOI' value='10.17487/RFC2104'/>
+</reference>

--- a/references/reference.RFC.2119.xml
+++ b/references/reference.RFC.2119.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC2119' target='https://www.rfc-editor.org/info/rfc2119'>
+<front>
+<title>Key words for use in RFCs to Indicate Requirement Levels</title>
+<author initials='S.' surname='Bradner' fullname='S. Bradner'><organization /></author>
+<date year='1997' month='March' />
+<abstract><t>In many standards track documents several words are used to signify the requirements in the specification.  These words are often capitalized. This document defines these words as they should be interpreted in IETF documents.  This document specifies an Internet Best Current Practices for the Internet Community, and requests discussion and suggestions for improvements.</t></abstract>
+</front>
+<seriesInfo name='BCP' value='14'/>
+<seriesInfo name='RFC' value='2119'/>
+<seriesInfo name='DOI' value='10.17487/RFC2119'/>
+</reference>

--- a/references/reference.RFC.2898.xml
+++ b/references/reference.RFC.2898.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC2898' target='https://www.rfc-editor.org/info/rfc2898'>
+<front>
+<title>PKCS #5: Password-Based Cryptography Specification Version 2.0</title>
+<author initials='B.' surname='Kaliski' fullname='B. Kaliski'><organization /></author>
+<date year='2000' month='September' />
+<abstract><t>This document provides recommendations for the implementation of password-based cryptography, covering key derivation functions, encryption schemes, message-authentication schemes, and ASN.1 syntax identifying the techniques.  This memo provides information for the Internet community.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='2898'/>
+<seriesInfo name='DOI' value='10.17487/RFC2898'/>
+</reference>

--- a/references/reference.RFC.3031.xml
+++ b/references/reference.RFC.3031.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC3031' target='https://www.rfc-editor.org/info/rfc3031'>
+<front>
+<title>Multiprotocol Label Switching Architecture</title>
+<author initials='E.' surname='Rosen' fullname='E. Rosen'><organization /></author>
+<author initials='A.' surname='Viswanathan' fullname='A. Viswanathan'><organization /></author>
+<author initials='R.' surname='Callon' fullname='R. Callon'><organization /></author>
+<date year='2001' month='January' />
+<abstract><t>This document specifies the architecture for Multiprotocol Label Switching (MPLS).  [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='3031'/>
+<seriesInfo name='DOI' value='10.17487/RFC3031'/>
+</reference>

--- a/references/reference.RFC.3394.xml
+++ b/references/reference.RFC.3394.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC3394' target='https://www.rfc-editor.org/info/rfc3394'>
+<front>
+<title>Advanced Encryption Standard (AES) Key Wrap Algorithm</title>
+<author initials='J.' surname='Schaad' fullname='J. Schaad'><organization /></author>
+<author initials='R.' surname='Housley' fullname='R. Housley'><organization /></author>
+<date year='2002' month='September' />
+</front>
+<seriesInfo name='RFC' value='3394'/>
+<seriesInfo name='DOI' value='10.17487/RFC3394'/>
+</reference>

--- a/references/reference.RFC.4987.xml
+++ b/references/reference.RFC.4987.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC4987' target='https://www.rfc-editor.org/info/rfc4987'>
+<front>
+<title>TCP SYN Flooding Attacks and Common Mitigations</title>
+<author initials='W.' surname='Eddy' fullname='W. Eddy'><organization /></author>
+<date year='2007' month='August' />
+<abstract><t>This document describes TCP SYN flooding attacks, which have been well-known to the community for several years.  Various countermeasures against these attacks, and the trade-offs of each, are described.  This document archives explanations of the attack and common defense techniques for the benefit of TCP implementers and administrators of TCP servers or networks, but does not make any standards-level recommendations.  This memo provides information for the Internet community.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='4987'/>
+<seriesInfo name='DOI' value='10.17487/RFC4987'/>
+</reference>

--- a/references/reference.RFC.6528.xml
+++ b/references/reference.RFC.6528.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC6528' target='https://www.rfc-editor.org/info/rfc6528'>
+<front>
+<title>Defending against Sequence Number Attacks</title>
+<author initials='F.' surname='Gont' fullname='F. Gont'><organization /></author>
+<author initials='S.' surname='Bellovin' fullname='S. Bellovin'><organization /></author>
+<date year='2012' month='February' />
+<abstract><t>This document specifies an algorithm for the generation of TCP Initial Sequence Numbers (ISNs), such that the chances of an off-path attacker guessing the sequence numbers in use by a target connection are reduced.  This document revises (and formally obsoletes) RFC 1948, and takes the ISN generation algorithm originally proposed in that document to Standards Track, formally updating RFC 793.   [STANDARDS-TRACK]</t></abstract>
+</front>
+<seriesInfo name='RFC' value='6528'/>
+<seriesInfo name='DOI' value='10.17487/RFC6528'/>
+</reference>

--- a/references/reference.RFC.8174.xml
+++ b/references/reference.RFC.8174.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC8174' target='https://www.rfc-editor.org/info/rfc8174'>
+<front>
+<title>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</title>
+<author initials='B.' surname='Leiba' fullname='B. Leiba'><organization /></author>
+<date year='2017' month='May' />
+<abstract><t>RFC 2119 specifies common key words that may be used in protocol  specifications.  This document aims to reduce the ambiguity by clarifying that only UPPERCASE usage of the key words have the  defined special meanings.</t></abstract>
+</front>
+<seriesInfo name='BCP' value='14'/>
+<seriesInfo name='RFC' value='8174'/>
+<seriesInfo name='DOI' value='10.17487/RFC8174'/>
+</reference>

--- a/references/reference.RFC.8216.xml
+++ b/references/reference.RFC.8216.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC8216' target='https://www.rfc-editor.org/info/rfc8216'>
+<front>
+<title>HTTP Live Streaming</title>
+<author initials='R.' surname='Pantos' fullname='R. Pantos' role='editor'><organization /></author>
+<author initials='W.' surname='May' fullname='W. May'><organization /></author>
+<date year='2017' month='August' />
+<abstract><t>This document describes a protocol for transferring unbounded streams of multimedia data.  It specifies the data format of the files and the actions to be taken by the server (sender) and the clients (receivers) of the streams.  It describes version 7 of this protocol.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='8216'/>
+<seriesInfo name='DOI' value='10.17487/RFC8216'/>
+</reference>

--- a/references/reference.RFC.8312.xml
+++ b/references/reference.RFC.8312.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<reference  anchor='RFC8312' target='https://www.rfc-editor.org/info/rfc8312'>
+<front>
+<title>CUBIC for Fast Long-Distance Networks</title>
+<author initials='I.' surname='Rhee' fullname='I. Rhee'><organization /></author>
+<author initials='L.' surname='Xu' fullname='L. Xu'><organization /></author>
+<author initials='S.' surname='Ha' fullname='S. Ha'><organization /></author>
+<author initials='A.' surname='Zimmermann' fullname='A. Zimmermann'><organization /></author>
+<author initials='L.' surname='Eggert' fullname='L. Eggert'><organization /></author>
+<author initials='R.' surname='Scheffenegger' fullname='R. Scheffenegger'><organization /></author>
+<date year='2018' month='February' />
+<abstract><t>CUBIC is an extension to the current TCP standards.  It differs from the current TCP standards only in the congestion control algorithm on the sender side.  In particular, it uses a cubic function instead of a linear window increase function of the current TCP standards to improve scalability and stability under fast and long-distance networks.  CUBIC and its predecessor algorithm have been adopted as defaults by Linux and have been used for many years.  This document provides a specification of CUBIC to enable third-party implementations and to solicit community feedback through experimentation on the performance of CUBIC.</t></abstract>
+</front>
+<seriesInfo name='RFC' value='8312'/>
+<seriesInfo name='DOI' value='10.17487/RFC8312'/>
+</reference>


### PR DESCRIPTION
This way is to avoid redundant downloading or build failing
by unknown network issue.