### PR TITLE
Ci update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: focal
 
 services:
   - docker


### PR DESCRIPTION
Travis-CI causes DNS resolving errors frequently.
Although it is not exactly the same issue[1],
their build host seems to have something related to DNS.
Hopefully, the build job works well with the newer host image.

[1] https://github.com/travis-ci/travis-ci/issues/9696