### PR TITLE
TLPKTDROP: explain magic number by variable.

### DIFF
--- a/draft-sharabayko-mops-srt.md
+++ b/draft-sharabayko-mops-srt.md
@@ -2021,8 +2021,8 @@ successfully received from the sender, the receiver will "skip" the packet
 and send a fake ACK. To the sender, this fake ACK is a real ACK ({{packet-acks}}), 
 and so it just behaves as if the packet had been received.
 This facilitates the synchronization between SRT sender and receiver. The fact that a packet was
-skipped remains unknown by the sender. Skipped packets are recorded in the statistics on the
-SRT receiver.
+skipped remains unknown by the sender. It is recommended that skipped packets are recorded
+in the statistics on the SRT receiver.
 
 ## Drift Management {#drift-management}
 

--- a/draft-sharabayko-mops-srt.md
+++ b/draft-sharabayko-mops-srt.md
@@ -2016,6 +2016,13 @@ longer, potentially undefined time, and cause even worse tearing
 for the player. Setting higher SRT latency will help much more in the
 case when TLPKTDROP causes packet drops too often.
 
+When a receiver encounters the situation where the next packet to be played was not
+successfully received from the sender, the receiver will "skip" the packet
+and send a fake ACK. To the sender, this fake ACK is a real ACK ({{packet-acks}}), 
+and so it just behaves as if the packet had been received.
+This facilitates the synchronization between SRT sender and receiver. The fact that a packet was
+skipped remains unknown by the sender. Skipped packets are recorded in the statistics on the
+SRT receiver.
 
 ## Drift Management {#drift-management}
 
@@ -2118,12 +2125,6 @@ received that the ACK position on the sender does not advance quickly enough. To
 after 64 packets (even if the ACK period has not fully elapsed) the receiver sends a light ACK.
 A light ACK is a shorter ACK (SRT header  and one 32-bit field). It does not trigger an ACKACK.
 
-When a receiver encounters the situation where the next packet to be played was not
-successfully received from the sender, it will "skip" this packet (see {{too-late-packet-drop}})
-and send a fake ACK. To the sender, this fake ACK is a real ACK, and so it just behaves as if the packet had been received.
-This facilitates the synchronization between SRT sender and receiver. The fact that a packet was
-skipped remains unknown by the sender. Skipped packets are recorded in the statistics on the
-SRT receiver.
 
 ### Packet Retransmission (NAKs) {#packet-naks}
 

--- a/draft-sharabayko-mops-srt.md
+++ b/draft-sharabayko-mops-srt.md
@@ -1961,10 +1961,20 @@ have no chance to be delivered in time, and allows the receiver to skip missing 
 that have not been delivered in time. The timeout of dropping a packet is based on the 
 TSBPD mechanism ({{tsbpd}}).
 
-In the SRT, when Too-Late Packet Drop is enabled, and a packet timestamp is older than 
-125% of the SRT latency, it is considered too late to be delivered and may be dropped
-by the sender. However, the sender keeps packets for at least 1 second in case the
-SRT latency is not enough for a large RTT (that is, if 125% of the SRT latency is less 
+With TLPKTDROP is enabled, when a packet timestamp is older than TLPKTDROP_THRESHOLD,
+the packet is considered "Too-Late" to be delivered. Thus, the sender might need to drop
+the packet.
+
+TLPKTDROP_THRESHOLD: a marginal value that defines a limit for when a packet is considered
+to be delivered in time. 
+: The value is related to SRT Latency ({{srt-latency}}). For an efficient packet drop mechanism,
+  it is recommended that a higher value than the latency be used. This will allow the receiver
+  to drop the packet first so that the sender drops the packet only when no proper response is
+  received from the peer (due to severe congestion, for example). When considering RTT, it is
+  recommended that the threshold value be 1.25 times the SRT Latency value.
+
+Note that the sender keeps packets for at least 1 second in case the
+SRT latency is not enough for a large RTT (that is, if TLPKTDROP_THRESHOLD is less 
 than 1 second).
 
 When enabled on the receiver, the receiver drops packets that have not been delivered 


### PR DESCRIPTION
I am not sure if I am reading the right point of the codes to understand this description.

https://github.com/Haivision/srt/blob/6012fdf483e8ddaca53a9f88e34ab5641c549b2a/srtcore/core.cpp#L5961

In that code, actually, I don't see "125%". Instead, `SRT_TLPKTDROP_MINTHRESHOLD_MS`(=1000ms) seems to play the main role to judge too-late packet drop.

As the comment on the 5947th line of the code, it might be reasonable to be an SRT socket option someday. If so, the description of RFC, I'd like to suggest explaining by `TLPKTDROP_THRESHOLD` variable. It is actually referencing magic number though.